### PR TITLE
Update dependencies for PureScript 0.14

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,12 +15,12 @@
     "output"
   ],
   "dependencies": {
-    "purescript-strings": "^4.0.0",
-    "purescript-lists": "^5.0.0",
-    "purescript-foldable-traversable": "^4.0.0"
+    "purescript-strings": "^5.0.0",
+    "purescript-lists": "^6.0.0",
+    "purescript-foldable-traversable": "^5.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^4.1.0",
-    "purescript-psci-support": "^4.0.0"
+    "purescript-console": "^5.0.0",
+    "purescript-psci-support": "^5.0.0"
   }
 }


### PR DESCRIPTION
This PR updates dependencies in the Bower file to those in the current `psc-0.14.0` package set. 
This is required in order to upgrade some downstream packages (see e.g. https://github.com/purescript-spec/purescript-spec/pull/113), which still rely on Bower for dependencies.